### PR TITLE
modal deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo contains deployment guides for the platforms listed below. Each guide 
 | [Droplet](https://www.digitalocean.com/products/droplets)   | [guide](https://github.com/AnswerDotAI/fh-deploy/tree/main/droplet) [Docker + SSL guide](https://github.com/AnswerDotAI/fh-deploy/tree/main/droplet-ssl-with-ci)     |
 | [Fly.io](https://fly.io/)              | [guide](https://github.com/AnswerDotAI/fh-deploy/tree/main/fly)         |
 | [Coolify](https://coolify.io/)         | [guide](https://github.com/AnswerDotAI/fh-deploy/tree/main/coolify)     |
+| [Modal](https://modal.com/)         | [guide](https://github.com/AnswerDotAI/fh-deploy/tree/main/modal)     |
 
 If you would like to add a guide for another platform feel free to fork this repo and submit a PR.
 

--- a/modal/README.md
+++ b/modal/README.md
@@ -1,0 +1,32 @@
+### Setup
+Run the commands below on your local machine.
+```bash
+git clone https://github.com/AnswerDotAI/fh-deploy.git
+cd modal
+pip install -r requirements.txt
+```
+
+### Run the app locally
+```bash
+python app.py
+```
+
+### Deploying to Modal
+
+First, install the [Modal](https://modal.com/) client:
+
+```bash
+pip install modal
+```
+
+Then, you need to obtain a token from Modal. Run the following command:
+
+```bash
+modal setup
+```
+
+Once that is set, you can setup the Modal app by running:
+
+```bash
+modal deploy deploy.py
+```

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,0 +1,9 @@
+from fasthtml.common import *
+
+fasthtml_app, rt = fast_app()
+
+@rt("/")
+def get():
+    return Titled("FastHTML", P("FastHTML on Modal!"))
+
+serve(app='fasthtml_app')

--- a/modal/deploy.py
+++ b/modal/deploy.py
@@ -1,0 +1,14 @@
+# Code from here: https://github.com/arihanv/fasthtml-modal/blob/main/deploy.py
+from modal import App, Image, asgi_app
+from app import fasthtml_app
+
+app = App(name="fasthtml-app")
+
+image = Image.debian_slim(python_version="3.11").pip_install(
+    "python-fasthtml"
+)
+
+@app.function(image=image)
+@asgi_app()
+def get():
+    return fasthtml_app

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -1,0 +1,1 @@
+python-fasthtml


### PR DESCRIPTION
Instructions and code for deploying **FastHTML** to [**Modal**](https://modal.com/).

Live example:
https://aastroza--fasthtml-app-get.modal.run/